### PR TITLE
Remove redundancy in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.env.dev
-.env.prod
-
 # Logs
 logs
 *.log


### PR DESCRIPTION
The two lines you added in the .gitignore are already within the .gitignore, Git committed them the first time because they were cached as not ignored.